### PR TITLE
Move manifest patch from rendering thread to loader thread

### DIFF
--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/DashManifestPatch.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/DashManifestPatch.java
@@ -95,7 +95,8 @@ public class DashManifestPatch {
             } else {
                 // Add Node
                 while (element.hasChildNodes()) {
-                    node.appendChild(element.getFirstChild());
+                    Node childNode = document.adoptNode(element.getFirstChild());
+                    node.appendChild(childNode);
                 }
             }
             return true;
@@ -134,7 +135,8 @@ public class DashManifestPatch {
                 Element node = (Element)xPath.compile(path).evaluate(document, XPathConstants.NODE);
                 Node parent = node.getParentNode();
                 if (element.getFirstChild() != null) {
-                    parent.replaceChild(element.getFirstChild(), node);
+                    Node childNode = document.adoptNode(element.getFirstChild());
+                    parent.replaceChild(childNode, node);
                 }
             }
             return true;

--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/DashManifestPatchMerger.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/DashManifestPatchMerger.java
@@ -1,0 +1,75 @@
+package com.google.android.exoplayer2.source.dash.manifest;
+
+import android.net.Uri;
+
+import androidx.annotation.Nullable;
+
+import com.google.android.exoplayer2.ParserException;
+import com.google.android.exoplayer2.source.dash.DashUtil;
+import com.google.android.exoplayer2.upstream.ParsingLoadable;
+import com.google.android.exoplayer2.util.Log;
+
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+public class DashManifestPatchMerger extends DefaultHandler
+        implements ParsingLoadable.Parser<DashManifest> {
+
+    private static final String TAG = "MpdPatchMerger";
+    private final DashManifestPatchParser parser;
+    private final DocumentBuilder documentBuilder;
+    @Nullable private Document document;
+    @Nullable private String manifestString;
+
+    public DashManifestPatchMerger() {
+        this(new DashManifestPatchParser());
+    }
+
+    public DashManifestPatchMerger(DashManifestPatchParser parser) {
+        this.parser = parser;
+        try {
+            DocumentBuilderFactory builder = DocumentBuilderFactory.newInstance();
+            documentBuilder = builder.newDocumentBuilder();
+        } catch (ParserConfigurationException e) {
+            throw new RuntimeException("Couldn't create Document instance", e);
+        }
+    }
+
+    public Document getDocument() {
+        return document;
+    }
+
+    public void setManifestString(String manifestString) throws IOException, SAXException {
+        if (this.manifestString != null && this.manifestString.equals(manifestString)) {
+            return;
+        }
+        this.manifestString = manifestString;
+        InputStream stream = new ByteArrayInputStream(manifestString.getBytes());
+        document = documentBuilder.parse(stream);
+    }
+
+    @Override
+    public DashManifest parse(Uri uri, InputStream inputStream) throws IOException {
+        String manifestPatchString = DashUtil.inputStreamToString(inputStream, "UTF-8");
+
+        DashManifestPatch patch = parser.parse(manifestPatchString);
+
+        if (!patch.applyPatch(document)) {
+            Log.d(TAG, "Failed to apply manifest patch: " + manifestPatchString);
+            throw new ParserException("Failed to apply manifest patch");
+        }
+
+        Log.d(TAG, "Patch success, operation count: " + patch.operations.size());
+        return DocumentToManifestConverter.convert(document, uri.toString());
+    }
+
+}

--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/DashManifestPatchParser.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/DashManifestPatchParser.java
@@ -1,20 +1,14 @@
 package com.google.android.exoplayer2.source.dash.manifest;
 
-import android.net.Uri;
-
 import androidx.annotation.Nullable;
 
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ParserException;
-import com.google.android.exoplayer2.source.dash.DashUtil;
-import com.google.android.exoplayer2.upstream.ParsingLoadable;
 import com.google.android.exoplayer2.util.Log;
 import com.google.android.exoplayer2.util.XmlPullParserUtil;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.DefaultHandler;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
@@ -23,18 +17,12 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
@@ -42,46 +30,24 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 
-public class DashManifestPatchParser extends DefaultHandler
-        implements ParsingLoadable.Parser<DashManifestPatch> {
+public class DashManifestPatchParser {
     private static final String TAG = "MpdPatchParser";
     private static final String UTF_8 = "UTF-8";
     private final XmlPullParserFactory xmlParserFactory;
-    private Document document;
     private DocumentBuilder documentBuilder;
+    @Nullable private Document document;
     @Nullable private Element root;
-    @Nullable private String manifestString;
-    @Nullable public String manifestPatchString;
 
     public DashManifestPatchParser() {
         try {
             xmlParserFactory = XmlPullParserFactory.newInstance();
             DocumentBuilderFactory builder = DocumentBuilderFactory.newInstance();
             documentBuilder = builder.newDocumentBuilder();
-            document = documentBuilder.newDocument();
         } catch (XmlPullParserException e) {
             throw new RuntimeException("Couldn't create XmlPullParserFactory instance", e);
         } catch (ParserConfigurationException e) {
             throw new RuntimeException("Couldn't create Document instance", e);
         }
-    }
-
-    public void setManifestString(String manifestString) throws IOException, SAXException {
-        if (this.manifestString != null && this.manifestString.equals(manifestString)) {
-            return;
-        }
-        this.manifestString = manifestString;
-        InputStream stream = new ByteArrayInputStream(manifestString.getBytes());
-        document = documentBuilder.parse(stream);
-        root = null;
-    }
-
-    public Document getDocument() {
-        return document;
-    }
-
-    public String getDocumentString() {
-        return docToString(document);
     }
 
     public static String docToString(Document doc) {
@@ -95,11 +61,9 @@ public class DashManifestPatchParser extends DefaultHandler
         }
     }
 
-    @Override
-    public DashManifestPatch parse(Uri uri, InputStream inputStream) throws IOException {
+    public DashManifestPatch parse(String manifestPatchString) throws IOException {
         try {
-            this.manifestPatchString = DashUtil.inputStreamToString(inputStream, "UTF-8");
-            InputStream textStream = new ByteArrayInputStream(this.manifestPatchString.getBytes());
+            InputStream textStream = new ByteArrayInputStream(manifestPatchString.getBytes());
 
             XmlPullParser xpp = xmlParserFactory.newPullParser();
             xpp.setInput(textStream, null);
@@ -108,27 +72,20 @@ public class DashManifestPatchParser extends DefaultHandler
                 throw new ParserException(
                         "inputStream does not contain a valid manifest patch");
             }
-            return parseDashManifestPatch(xpp, uri.toString());
+            return parseDashManifestPatch(xpp);
         } catch (XmlPullParserException e) {
             throw new ParserException(e);
         }
     }
 
-    protected DashManifestPatch parseDashManifestPatch(XmlPullParser xpp,
-                                                  String baseUrl) throws XmlPullParserException, IOException {
+    protected DashManifestPatch parseDashManifestPatch(XmlPullParser xpp) throws XmlPullParserException, IOException {
         String mpdId = DashManifestParser.parseString(xpp, "mpdId", "");
         long originalPublishTime = DashManifestParser.parseDateTime(xpp, "originalPublishTime", C.TIME_UNSET);
         long publishTime = DashManifestParser.parseDateTime(xpp, "publishTime", C.TIME_UNSET);
 
-        if (root == null) {
-            root = document.createElement("Patch");
-            if (document.getDocumentElement() == null) {
-                document.appendChild(root);
-            }
-        }
-        while (root.hasChildNodes()) {
-            root.removeChild(root.getFirstChild());
-        }
+        document = documentBuilder.newDocument();
+        root = document.createElement("Patch");
+        document.appendChild(root);
 
         List<DashManifestPatch.Operation> operationList = new ArrayList<>();
         do {

--- a/library/dash/src/test/java/com/google/android/exoplayer2/source/dash/manifest/DashManifestPatchParserTest.java
+++ b/library/dash/src/test/java/com/google/android/exoplayer2/source/dash/manifest/DashManifestPatchParserTest.java
@@ -1,6 +1,5 @@
 package com.google.android.exoplayer2.source.dash.manifest;
 
-import android.net.Uri;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.android.exoplayer2.testutil.TestUtil;
@@ -27,8 +26,7 @@ public class DashManifestPatchParserTest {
     public void testParseSamplePatch() throws IOException {
         DashManifestPatchParser parser = new DashManifestPatchParser();
         DashManifestPatch patch = parser.parse(
-                Uri.parse("https://example.com/test.mpd"),
-                TestUtil.getInputStream(ApplicationProvider.getApplicationContext(), SAMPLE_MPD_PATCH));
+                TestUtil.getString(ApplicationProvider.getApplicationContext(), SAMPLE_MPD_PATCH));
 
         assertThat(patch.mpdId).isEqualTo("mpd-id");
         assertThat(patch.originalPublishTimeMs).isEqualTo(Util.parseXsDateTime("2020-11-09T03:48:41.51468868Z"));
@@ -42,8 +40,7 @@ public class DashManifestPatchParserTest {
     public void testParseAddOperationWithSegments() throws IOException {
         DashManifestPatchParser parser = new DashManifestPatchParser();
         DashManifestPatch patch = parser.parse(
-                Uri.parse("https://example.com/test.mpd"),
-                TestUtil.getInputStream(ApplicationProvider.getApplicationContext(), SAMPLE_MPD_PATCH_ADD_SEGMENTS));
+                TestUtil.getString(ApplicationProvider.getApplicationContext(), SAMPLE_MPD_PATCH_ADD_SEGMENTS));
 
         assertThat(patch.operations.size()).isEqualTo(1);
         DashManifestPatch.AddOperation operation = (DashManifestPatch.AddOperation)patch.operations.get(0);
@@ -57,8 +54,7 @@ public class DashManifestPatchParserTest {
     public void testParseAddOperationWithPeriod() throws IOException {
         DashManifestPatchParser parser = new DashManifestPatchParser();
         DashManifestPatch patch = parser.parse(
-                Uri.parse("https://example.com/test.mpd"),
-                TestUtil.getInputStream(ApplicationProvider.getApplicationContext(), SAMPLE_MPD_PATCH_ADD_PERIOD));
+                TestUtil.getString(ApplicationProvider.getApplicationContext(), SAMPLE_MPD_PATCH_ADD_PERIOD));
 
         assertThat(patch.operations.size()).isEqualTo(1);
         DashManifestPatch.AddOperation operation = (DashManifestPatch.AddOperation)patch.operations.get(0);
@@ -72,8 +68,7 @@ public class DashManifestPatchParserTest {
     public void testParseAddAttribute() throws IOException {
         DashManifestPatchParser parser = new DashManifestPatchParser();
         DashManifestPatch patch = parser.parse(
-                Uri.parse("https://example.com/test.mpd"),
-                TestUtil.getInputStream(ApplicationProvider.getApplicationContext(), SAMPLE_MPD_PATCH_ADD_ATTRIBUTE));
+                TestUtil.getString(ApplicationProvider.getApplicationContext(), SAMPLE_MPD_PATCH_ADD_ATTRIBUTE));
 
         assertThat(patch.operations.size()).isEqualTo(1);
         DashManifestPatch.AddOperation operation = (DashManifestPatch.AddOperation)patch.operations.get(0);
@@ -87,8 +82,7 @@ public class DashManifestPatchParserTest {
     public void testParseReplaceAttribute() throws IOException {
         DashManifestPatchParser parser = new DashManifestPatchParser();
         DashManifestPatch patch = parser.parse(
-                Uri.parse("https://example.com/test.mpd"),
-                TestUtil.getInputStream(ApplicationProvider.getApplicationContext(),
+                TestUtil.getString(ApplicationProvider.getApplicationContext(),
                                         SAMPLE_MPD_PATCH_REPLACE_ATTRIBUTE));
 
         assertThat(patch.operations.size()).isEqualTo(1);
@@ -101,8 +95,7 @@ public class DashManifestPatchParserTest {
     public void testParseReplaceNode() throws IOException {
         DashManifestPatchParser parser = new DashManifestPatchParser();
         DashManifestPatch patch = parser.parse(
-                Uri.parse("https://example.com/test.mpd"),
-                TestUtil.getInputStream(ApplicationProvider.getApplicationContext(), SAMPLE_MPD_PATCH_REPLACE_NODE));
+                TestUtil.getString(ApplicationProvider.getApplicationContext(), SAMPLE_MPD_PATCH_REPLACE_NODE));
 
         assertThat(patch.operations.size()).isEqualTo(1);
         DashManifestPatch.ReplaceOperation operation = (DashManifestPatch.ReplaceOperation)patch.operations.get(0);

--- a/library/dash/src/test/java/com/google/android/exoplayer2/source/dash/manifest/DocumentToManifestConverterTest.java
+++ b/library/dash/src/test/java/com/google/android/exoplayer2/source/dash/manifest/DocumentToManifestConverterTest.java
@@ -30,9 +30,9 @@ public class DocumentToManifestConverterTest {
                 Uri.parse(baseURL),
                 TestUtil.getInputStream(ApplicationProvider.getApplicationContext(), MPD_WITH_PATCH));
 
-        DashManifestPatchParser patchParser = new DashManifestPatchParser();
-        patchParser.setManifestString(TestUtil.getString(ApplicationProvider.getApplicationContext(), MPD_WITH_PATCH));
-        DashManifest convertedManifest = DocumentToManifestConverter.convert(patchParser.getDocument(), baseURL);
+        DashManifestPatchMerger patchMerger = new DashManifestPatchMerger();
+        patchMerger.setManifestString(TestUtil.getString(ApplicationProvider.getApplicationContext(), MPD_WITH_PATCH));
+        DashManifest convertedManifest = DocumentToManifestConverter.convert(patchMerger.getDocument(), baseURL);
 
         Gson gson = new Gson();
         assertThat(gson.toJson(manifest)).isEqualTo(gson.toJson(convertedManifest));
@@ -46,9 +46,9 @@ public class DocumentToManifestConverterTest {
                 Uri.parse(baseURL),
                 TestUtil.getInputStream(ApplicationProvider.getApplicationContext(), MPD_WITH_MULTI_PERIOD_SCTE35));
 
-        DashManifestPatchParser patchParser = new DashManifestPatchParser();
-        patchParser.setManifestString(TestUtil.getString(ApplicationProvider.getApplicationContext(), MPD_WITH_MULTI_PERIOD_SCTE35));
-        DashManifest convertedManifest = DocumentToManifestConverter.convert(patchParser.getDocument(), baseURL);
+        DashManifestPatchMerger patchMerger = new DashManifestPatchMerger();
+        patchMerger.setManifestString(TestUtil.getString(ApplicationProvider.getApplicationContext(), MPD_WITH_MULTI_PERIOD_SCTE35));
+        DashManifest convertedManifest = DocumentToManifestConverter.convert(patchMerger.getDocument(), baseURL);
 
         Gson gson = new Gson();
         assertThat(gson.toJson(manifest)).isEqualTo(gson.toJson(convertedManifest));


### PR DESCRIPTION
Move manifest patch from rendering thread to loader thread due to video jitter when DVR windows is long (e.g. more than 1 hour)